### PR TITLE
Used a lint to find issue

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,13 +11,12 @@
     {
       "name": "puppet",
       "version_requirement": ">= 4.x"
-    },
+    }
   ],
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.6.0"
-    },
-  ],
-
+    }
+  ]
 }


### PR DESCRIPTION
puppet-librarian barfed. This should fix it.

```
[Librarian]     --> 43ff75f801041f11670f69532facc6a20ea408e8
/usr/share/gems/gems/json-1.7.7/lib/json/common.rb:155:in `parse': 399: unexpected token at '], (JSON::ParserError)
  "dependencies": [
    {
      "name": "puppetlabs-stdlib",
      "version_requirement": ">= 4.6.0"
    },
  ],

}'
        from /usr/share/gems/gems/json-1.7.7/lib/json/common.rb:155:in `parse'
...
```
