### PR TITLE
Support for the jcr:mixinTypes property

### DIFF
--- a/manifests/agent/replication.pp
+++ b/manifests/agent/replication.pp
@@ -73,7 +73,7 @@ define aem::agent::replication(
 
   if $ensure == 'present' {
     if $mixin_types {
-       validate_array($mixin_types)
+      validate_array($mixin_types)
     }
 
     if $batch_enabled {

--- a/manifests/agent/replication.pp
+++ b/manifests/agent/replication.pp
@@ -13,6 +13,7 @@ define aem::agent::replication(
   $force_passwords       = undef,
   $home                  = undef,
   $log_level             = 'info',
+  $mixin_types           = undef,
   $password              = undef,
   $protocol_close_conn   = undef,
   $protocol_conn_timeout = undef,
@@ -71,6 +72,9 @@ define aem::agent::replication(
   }
 
   if $ensure == 'present' {
+    if $mixin_types {
+       validate_array($mixin_types)
+    }
 
     if $batch_enabled {
       validate_bool($batch_enabled)
@@ -181,6 +185,7 @@ define aem::agent::replication(
     'jcr:description'             => $_description,
     'enabled'                     => $enabled,
     'logLevel'                    => $log_level,
+    'jcr:mixinTypes'              => $mixin_types,
     'protocolHTTPConnectionClose' => $protocol_close_conn,
     'protocolConnectTimeout'      => $protocol_conn_timeout,
     'protocolHTTPHeaders'         => $protocol_http_headers,
@@ -215,7 +220,7 @@ define aem::agent::replication(
     'triggerDistribute'           => $trigger_on_dist,
     'triggerModified'             => $trigger_on_mod,
     'triggerReceive'              => $trigger_on_receive,
-    'triggerOnOffTime'            => $trigger_onoff_time
+    'triggerOnOffTime'            => $trigger_onoff_time,
   }
 
   $_resource_props = delete_undef_values($resource_props)

--- a/spec/acceptance/aem/replication_spec.rb
+++ b/spec/acceptance/aem/replication_spec.rb
@@ -28,6 +28,7 @@ describe 'create replication agent', license: false do
           enabled               => false,
           home                  => \"/opt/aem/author\",
           log_level             => \"debug\",
+          mixin_types           => [\"cq:ReplicationStatus\"],
           name                  => \"customname\",
           password              => \"admin\",
           protocol_close_conn   => true,
@@ -109,6 +110,7 @@ describe 'create replication agent', license: false do
       expect(jsonresult['jcr:content']['jcr:description']).to eq(desc)
       expect(jsonresult['jcr:content']['enabled']).to eq('false')
       expect(jsonresult['jcr:content']['logLevel']).to eq('debug')
+      expect(jsonresult['jcr:content']['jcr:mixinTypes']).to match_array(['cq:ReplicationStatus'])
       expect(jsonresult['jcr:content']['protocolHTTPConnectionClose']).to eq('true')
       expect(jsonresult['jcr:content']['protocolConnectTimeout']).to eq('1000')
       expect(

--- a/spec/defines/agent/replication/replication_spec.rb
+++ b/spec/defines/agent/replication/replication_spec.rb
@@ -142,6 +142,7 @@ describe 'aem::agent::replication', type: :defines do
           enabled: false,
           home: '/opt/aem',
           log_level: 'debug',
+          mixin_types: ['cq:ReplicationStatus']
           name: 'customname',
           password: 'apassword',
           protocol_close_conn: true,
@@ -205,6 +206,7 @@ describe 'aem::agent::replication', type: :defines do
               'jcr:description'             => "#{default_desc}Custom Description",
               'enabled'                     => false,
               'logLevel'                    => 'debug',
+              'jcr:mixinTypes'              => ['cq:ReplicationStatus']
               'protocolHTTPConnectionClose' => true,
               'protocolConnectTimeout'      => 1000,
               'protocolHTTPHeaders'         => ['CQ-Action:{action}', 'CQ-Handle:{path}', 'CQ-Path:{path}'],

--- a/spec/defines/agent/replication/replication_spec.rb
+++ b/spec/defines/agent/replication/replication_spec.rb
@@ -142,7 +142,7 @@ describe 'aem::agent::replication', type: :defines do
           enabled: false,
           home: '/opt/aem',
           log_level: 'debug',
-          mixin_types: ['cq:ReplicationStatus']
+          mixin_types: ['cq:ReplicationStatus'],
           name: 'customname',
           password: 'apassword',
           protocol_close_conn: true,
@@ -206,7 +206,7 @@ describe 'aem::agent::replication', type: :defines do
               'jcr:description'             => "#{default_desc}Custom Description",
               'enabled'                     => false,
               'logLevel'                    => 'debug',
-              'jcr:mixinTypes'              => ['cq:ReplicationStatus']
+              'jcr:mixinTypes'              => ['cq:ReplicationStatus'],
               'protocolHTTPConnectionClose' => true,
               'protocolConnectTimeout'      => 1000,
               'protocolHTTPHeaders'         => ['CQ-Action:{action}', 'CQ-Handle:{path}', 'CQ-Path:{path}'],


### PR DESCRIPTION
For provisioning outbox agents the jcr:mixinTypes node has to be included.
