### PR TITLE
Correct Aem::Service resource name in documentation and examples

### DIFF
--- a/docs/license/Default.md
+++ b/docs/license/Default.md
@@ -16,7 +16,7 @@ aem::license { 'aem' :
 
 # Ensure the service doesn't start before license is available
 
-Aem::License['aem'] ~> Aem::Service['aem-aem']
+Aem::License['aem'] ~> Aem::Service['aem']
 ~~~
 
-*The default service definition created for AEM is pre-pended with 'aem-', to ensure uniqueness, thus the service reference is 'aem-aem'.*
+*The Aem::Service definition created for AEM uses the aem::instance $name to ensure uniqueness, thus here the service reference is 'aem'.*

--- a/docs/license/Home-Directory.md
+++ b/docs/license/Home-Directory.md
@@ -16,5 +16,7 @@ aem::license { 'aem' :
   version     => '6.1.0',
 }
 
-Aem::License['aem'] ~> Aem::Service['aem-aem']
+Aem::License['aem'] ~> Aem::Service['aem']
 ~~~
+
+*The Aem::Service definition created for AEM uses the aem::instance $name to ensure uniqueness, thus here the service reference is 'aem'.*

--- a/docs/license/User-Group.md
+++ b/docs/license/User-Group.md
@@ -19,5 +19,7 @@ aem::license { 'aem' :
   group       => 'vagrant',
 }
 
-Aem::License['aem'] ~> Aem::Service['aem-aem']
+Aem::License['aem'] ~> Aem::Service['aem']
 ~~~
+
+*The Aem::Service definition created for AEM uses the aem::instance $name to ensure uniqueness, thus here the service reference is 'aem'.*

--- a/examples/license/default.pp
+++ b/examples/license/default.pp
@@ -12,4 +12,4 @@ aem::license { 'aem' :
 }
 
 # Ensure the service doesn't start before license is available
-Aem::License['aem'] ~> Aem::Service['aem-aem']
+Aem::License['aem'] ~> Aem::Service['aem']

--- a/examples/license/home-directory.pp
+++ b/examples/license/home-directory.pp
@@ -13,4 +13,4 @@ aem::license { 'aem' :
   version     => '6.1.0',
 }
 
-Aem::License['aem'] ~> Aem::Service['aem-aem']
+Aem::License['aem'] ~> Aem::Service['aem']

--- a/examples/license/user-group.pp
+++ b/examples/license/user-group.pp
@@ -16,4 +16,4 @@ aem::license { 'aem' :
   group       => 'vagrant',
 }
 
-Aem::License['aem'] ~> Aem::Service['aem-aem']
+Aem::License['aem'] ~> Aem::Service['aem']


### PR DESCRIPTION
The Puppet Service resource does get the 'aem-' string prepended
but the Aem::Service resource uses the Aem::Instance $name var.