### PR TITLE
Set correct SELinux type on Dispatcher .so files - Fixes #73

### DIFF
--- a/manifests/dispatcher.pp
+++ b/manifests/dispatcher.pp
@@ -69,6 +69,7 @@ class aem::dispatcher (
       group   => $group,
       owner   => $user,
       replace => true,
+      seltype => 'httpd_module_t',
       source  => $module_file,
     }
 
@@ -77,6 +78,7 @@ class aem::dispatcher (
       group   => $group,
       owner   => $user,
       replace => true,
+      seltype => 'httpd_module_t',
       target  => "${::aem::dispatcher::params::mod_path}/${_mod_filename}",
     }
 


### PR DESCRIPTION
Setting seltype httpd_modules_t so the Dispatcher .so files will be loaded correctly by Apache