### PR TITLE
Allowing literal values for file type OSGi configs.

### DIFF
--- a/spec/defines/osgi/config/file_spec.rb
+++ b/spec/defines/osgi/config/file_spec.rb
@@ -135,7 +135,7 @@ describe 'aem::osgi::config::file', type: :defines do
         is_expected.to contain_file(
           '/opt/aem/crx-quickstart/install/aem.config'
         ).with_content(
-          /simple_string_literal=T"simple string"\s/
+          /simple_string_literal="simple string"\s/
         )
       end
     end

--- a/spec/defines/osgi/config/file_spec.rb
+++ b/spec/defines/osgi/config/file_spec.rb
@@ -135,7 +135,7 @@ describe 'aem::osgi::config::file', type: :defines do
         is_expected.to contain_file(
           '/opt/aem/crx-quickstart/install/aem.config'
         ).with_content(
-           /simple_string_literal=L"simple string"\s/
+           /simple_string_literal=T"simple string"\s/
         )
       end
     end

--- a/spec/defines/osgi/config/file_spec.rb
+++ b/spec/defines/osgi/config/file_spec.rb
@@ -20,10 +20,21 @@ describe 'aem::osgi::config::file', type: :defines do
       home: '/opt/aem',
       pid: :undef,
       properties: {
-        'boolean' => false,
-        'long'    => 123_456_789,
-        'string'  => 'string',
-        'array'   => ['an', 'array', 'of', 'values']
+        'boolean'                 => false,
+        'long'                    => 123_456_789,
+        'string'                  => 'string',
+        'array'                   => ['an', 'array', 'of', 'values'],
+        'simple_string_literal'   => 'T"simple string"',
+        'integer_literal'         => 'I"10"',
+        'long_literal'            => 'L"99"',
+        'float_literal'           => 'F"3.14"',
+        'double_literal'          => 'D"9.99"',
+        'byte_literal'            => 'X"Y"',
+        'short_literal'           => 'S"100"',
+        'character_literal'       => 'C"X"',
+        'boolean_literal'         => 'B"false"',
+        'unknown_type_literal'    => 'A"foo"',
+        'wrong_format_literal'    => 'T"false" ',
       },
       user: 'aem'
     }
@@ -114,6 +125,127 @@ describe 'aem::osgi::config::file', type: :defines do
           '/opt/aem/crx-quickstart/install/aem.config'
         ).with_content(
           /array=\["an","array","of","values"\]/
+        )
+      end
+    end
+    
+    context 'simple string literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+           /simple_string_literal=L"simple string"\s/
+        )
+      end
+    end
+
+    context 'integer literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /integer_literal=I"10"\s/
+        )
+      end
+    end
+
+    context 'long literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /long_literal=L"99"\s/
+        )
+      end
+    end
+
+    context 'float literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /float_literal=F"3.14"\s/
+        )
+      end
+    end
+
+    context 'double literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /double_literal=D"9.99"\s/
+        )
+      end
+    end
+
+    context 'byte literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /byte_literal=X"Y"\s/
+        )
+      end
+    end
+
+    context 'short literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /short_literal=S"100"\s/
+        )
+      end
+    end
+
+    context 'character literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /character_literal=C"X"\s/
+        )
+      end
+    end
+
+    context 'boolean literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /boolean_literal=B"false"\s/
+        )
+      end
+    end
+
+    context 'unknown type literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /unknown_type_literal="A"foo""\s/
+        )
+      end
+    end
+
+    context 'wrong format literal' do
+
+      it do
+        is_expected.to contain_file(
+          '/opt/aem/crx-quickstart/install/aem.config'
+        ).with_content(
+          /wrong_format_literal="T"false" "\s/
         )
       end
     end

--- a/spec/defines/osgi/config/file_spec.rb
+++ b/spec/defines/osgi/config/file_spec.rb
@@ -34,7 +34,7 @@ describe 'aem::osgi::config::file', type: :defines do
         'character_literal'       => 'C"X"',
         'boolean_literal'         => 'B"false"',
         'unknown_type_literal'    => 'A"foo"',
-        'wrong_format_literal'    => 'T"false" ',
+        'wrong_format_literal'    => 'T"false" '
       },
       user: 'aem'
     }
@@ -128,14 +128,14 @@ describe 'aem::osgi::config::file', type: :defines do
         )
       end
     end
-    
+
     context 'simple string literal' do
 
       it do
         is_expected.to contain_file(
           '/opt/aem/crx-quickstart/install/aem.config'
         ).with_content(
-           /simple_string_literal=T"simple string"\s/
+          /simple_string_literal=T"simple string"\s/
         )
       end
     end

--- a/templates/osgi.config.epp
+++ b/templates/osgi.config.epp
@@ -6,7 +6,10 @@ service.pid="<%= $pid %>"
 <%- $properties.keys.each | String $key | { -%>
   <%- if is_array($properties[$key]) { -%>
 <%= $key -%>=["<%= $properties[$key].join('","') -%>"]
-  <%- } elsif is_string($properties[$key]) and $properties[$key] =~ /^[T|I|L|F|D|X|S|C|B]".*"$/ { -%>
+  <%- } elsif is_string($properties[$key]) and $properties[$key] =~ /^[T]".*"$/ { -%>
+<%= $key -%>=<%= $properties[$key].match(/^[T](".*")$/)[1] -%>
+
+  <%- } elsif is_string($properties[$key]) and $properties[$key] =~ /^[I|L|F|D|X|S|C|B]".*"$/ { -%>
 <%= $key -%>=<%= $properties[$key] -%>
 
   <%- } else {-%>

--- a/templates/osgi.config.epp
+++ b/templates/osgi.config.epp
@@ -6,6 +6,9 @@ service.pid="<%= $pid %>"
 <%- $properties.keys.each | String $key | { -%>
   <%- if is_array($properties[$key]) { -%>
 <%= $key -%>=["<%= $properties[$key].join('","') -%>"]
+  <%- } elsif is_string($properties[$key]) and $properties[$key] =~ /^[T|I|L|F|D|X|S|C|B]".*"$/ { -%>
+<%= $key -%>=<%= $properties[$key] -%>
+
   <%- } else {-%>
     <%- if is_bool($properties[$key]) { -%>
       <%- $type = "B" -%>


### PR DESCRIPTION
I need to be able to set the necessary OSGi configs for the S3SharedDataSource, but the puppet module will change the data I provide in an unexpected way:

This is the hiera data:

  - org.apache.jackrabbit.oak.plugins.blob.datastore.SharedS3DataStore:
      path: "%{lookup('profiles::aem::instance::home')}/datastore"
      s3Bucket: "387323646340-%{facts.ec2_tag_aem_environment}-aem-datastore"
      s3Region: "eu-west-1"
      connectionTimeout: '120000'
      maxConnections: '40'
      maxErrorRetry: '10'
      socketTimeout: '120000'

This is the resulting OSGi config:

service.pid="org.apache.jackrabbit.oak.plugins.blob.datastore.SharedS3DataStore"
path="/data/apps/aem/datastore"
s3Bucket="387323646340--aem-datastore"
s3Region="eu-west-1"
connectionTimeout=L"120000"
maxConnections=L"40"
maxErrorRetry=L"10"
socketTimeout=L"120000"

However, values with a 'L' prefix should be normal strings for the plugin to work. 

So this pull request would allow me to specify the values in a literal way, without them being changed. The change should also be backwards compatible.