### PR TITLE
Set pkg property in provider

### DIFF
--- a/lib/puppet/provider/aem_crx_package/ruby.rb
+++ b/lib/puppet/provider/aem_crx_package/ruby.rb
@@ -121,6 +121,7 @@ Puppet::Type.type(:aem_crx_package).provide :ruby, parent: Puppet::Provider do
     found_pkg = find_version(data.results)
     Puppet.debug("aem_crx_package::ruby - Found package: #{found_pkg}")
     if found_pkg
+      @property_hash[:pkg] = found_pkg.name
       @property_hash[:group] = found_pkg.group
       @property_hash[:version] = found_pkg.version
       @property_hash[:ensure] = found_pkg.last_unpacked ? :installed : :present


### PR DESCRIPTION
This removes the puppet notice about setting 'pkg' on each run.

==> author1: Notice:
/Stage[main]/Profiles::Aem::Instance/Aem::Crx::Package[core.wcm.components.all_1.0.0]/Aem_crx_package[core.wcm.components.all_1.0.0]/pkg:
defined 'pkg' as 'core.wcm.components.all'