### PR TITLE
Support regex in dispatcher config

### DIFF
--- a/docs/dispatcher/Filters.md
+++ b/docs/dispatcher/Filters.md
@@ -20,6 +20,18 @@ There are two methods for defining a Filter hash. If the hash contains the _glob
   * extension
   * suffix
 
+As of Dispatcher version 4.2.0 there is [support for POSIX regular expressions](https://helpx.adobe.com/experience-manager/dispatcher/using/dispatcher-configuration.html#main-pars_title_1996763852) for the following values:
+
+  * url
+  * query
+  * protocol
+  * path
+  * selectors
+  * extension
+  * suffix
+
+If you want to use a POSIX regular expression you must encapsulate it in single quotes.
+
 #### Glob Example
 
 This example creates a Farm definition with custom filter rules, using a glob example:
@@ -28,8 +40,8 @@ This example creates a Farm definition with custom filter rules, using a glob ex
 aem::dispatcher::farm { 'site' :
   docroot => '/var/www',
   filters => [
-    { 
-      'rank' => 310, 
+    {
+      'rank' => 310,
       'type' => 'allow',
       'glob' => '*.html',
     },
@@ -56,7 +68,7 @@ This definition will create a file *dispatcher.site.any* with the following cont
   }
 
   /renders {
-    /renderer0 { 
+    /renderer0 {
       /hostname "localhost"
       /port "4503"
     }
@@ -98,8 +110,8 @@ aem::dispatcher::farm { 'site' :
       'rank'      => 310,
       'type'      => 'allow',
       'path'      => '/content',
-      'selectors' => '(feed|rss|pages|languages|blueprint|infinity|tidy)'
-      'extension' => '(json|xml|html)'
+      'selectors' => '\'(feed|rss|pages|languages|blueprint|infinity|tidy)\''
+      'extension' => '\'(json|xml|html)\''
     },
     {
       'rank' => 300,
@@ -135,8 +147,8 @@ This definition will create a file *dispatcher.site.any* with the following cont
     /1 {
       /type "allow"
       /path "/content"
-      /selectors '(feed|rss|pages|languages|blueprint|infinity|tidy)'
-      /extension '(json|xml|html)'
+      /selectors '\'(feed|rss|pages|languages|blueprint|infinity|tidy)\''
+      /extension '\'(json|xml|html)\''
     }
   }
 

--- a/lib/puppet/parser/functions/render_farm_filter.rb
+++ b/lib/puppet/parser/functions/render_farm_filter.rb
@@ -1,0 +1,21 @@
+# Puppet parser extension to render a farm filter
+module Puppet
+  module Parser
+    # Function definition of render_farm_filter
+    module Functions
+      newfunction(:render_farm_filter, type: :rvalue) do |args|
+        # Validate input
+        unless args.length == 1
+          raise Puppet::ParseError, "render_farm_filter(): wrong number of arguments (#{args.length}; must be 1)"
+        end
+
+        unless args[0].is_a?(String)
+          raise Puppet::ParseError, 'render_farm_filter(): argument should be an string.'
+        end
+
+        return args[0] if args[0].start_with?("'") && args[0].end_with?("'")
+        return '"' + args[0] + '"'
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/aem_installer/default.rb
+++ b/lib/puppet/provider/aem_installer/default.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:aem_installer).provide :default, parent: Puppet::Provider do
     @stop_file = 'stop'
     @launchpad_name = 'cq-quickstart-*-standalone*.jar'
     @repository_dir = 'repository'
-    @quickstart_fields = [:home, :version]
+    @quickstart_fields = %i[home version]
     @quickstart_regex = %r|^(\S+)/crx-quickstart/app/cq-quickstart-([0-9.]+)-standalone.*\.jar$|
     @port_regex = /^PORT=(\S+)/
     @context_root_regex = /^CONTEXT_ROOT='(\S+)'/

--- a/lib/puppet/type/aem_installer.rb
+++ b/lib/puppet/type/aem_installer.rb
@@ -66,7 +66,7 @@ This is a private type intended to start, monitor, and stop an AEM instance, ins
     autos
   end
 
-  [:user, :group].each do |type|
+  %i[user group].each do |type|
     autorequire(type) do
       if @parameters.include?(type)
         val = @parameters[type]

--- a/spec/defines/dispatcher/farm/template_spec.rb
+++ b/spec/defines/dispatcher/farm/template_spec.rb
@@ -231,9 +231,9 @@ describe 'aem::dispatcher::farm', type: :define do
                 'query'     => 'param=*',
                 'protocol'  => 'https',
                 'path'      => '/different/path/to/content',
-                'selectors' => '((sys|doc)view|query|[0-9-]+)',
-                'extension' => '(css|gif|ico|js|png|swf|jpe?g)',
-                'suffix'    => '/suffix/path'
+                'selectors' => '\'((sys|doc)view|query|[0-9-]+)\'',
+                'extension' => '\'(css|gif|ico|js|png|swf|jpe?g)\'',
+                'suffix'    => '\'/suffix/path\''
               }
             )
           end
@@ -278,6 +278,25 @@ describe 'aem::dispatcher::farm', type: :define do
           end
         end
 
+        context 'method regex' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'   => 'allow',
+                'method' => '\'(GET|HEAD)\''
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/method\s*\'\(GET\|HEAD\)\'\s*}|
+            )
+          end
+        end
+
         context 'url value' do
           let(:params) do
             default_params.merge(
@@ -293,6 +312,25 @@ describe 'aem::dispatcher::farm', type: :define do
               '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
             ).with_content(
               %r|/0 {\s*/type\s*"allow"\s*/url\s*"/path/to/content"\s*}|
+            )
+          end
+        end
+
+        context 'url regex' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type' => 'allow',
+                'url'  => '\'/path/to/(content|lib)/?\''
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/url\s*\'/path/to/\(content\|lib\)/\?\'\s*}|
             )
           end
         end
@@ -316,6 +354,25 @@ describe 'aem::dispatcher::farm', type: :define do
           end
         end
 
+        context 'query regex' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'     => 'allow',
+                'query'    => '\'param=.*\''
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/query\s*\'param=\.\*\'\s*}|
+            )
+          end
+        end
+
         context 'protocol' do
           let(:params) do
             default_params.merge(
@@ -331,6 +388,177 @@ describe 'aem::dispatcher::farm', type: :define do
               '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
             ).with_content(
               %r|/0 {\s*/type\s*"allow"\s*/protocol\s"https"\s*}|
+            )
+          end
+        end
+
+        context 'protocol regex' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'     => 'allow',
+                'protocol' => '\'https?\''
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/protocol\s\'https\?\'\s*}|
+            )
+          end
+        end
+
+        context 'path' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type' => 'allow',
+                'path' => '/path/to/content'
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/path\s*"/path/to/content"\s*}|
+            )
+          end
+        end
+
+        context 'path regex' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type' => 'allow',
+                'path' => '\'/path/to/(content|lib)/?\''
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/path\s*\'/path/to/\(content\|lib\)/\?\'\s*}|
+            )
+          end
+        end
+
+        context 'selectors' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'      => 'allow',
+                'selectors' => 'thumb'
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/selectors\s"thumb"\s*}|
+            )
+          end
+        end
+
+        context 'selectors regex' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'      => 'allow',
+                'selectors' => '\'[0-9]+\''
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/selectors\s\'\[0-9\]\+\'\s*}|
+            )
+          end
+        end
+
+        context 'extension' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'      => 'allow',
+                'extension' => 'ico'
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/extension\s"ico"\s*}|
+            )
+          end
+        end
+
+        context 'extension regex' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'      => 'allow',
+                'extension' => '\'(ico|png)\''
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/extension\s\'\(ico\|png\)\'\s*}|
+            )
+          end
+        end
+
+        context 'suffix' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'   => 'allow',
+                'suffix' => '/suffix/path'
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/suffix\s"/suffix/path"\s*}|
+            )
+          end
+        end
+
+        context 'suffix regex' do
+          let(:params) do
+            default_params.merge(
+              filters: {
+                'type'   => 'allow',
+                'suffix' => '\'/suffix/path/.*\''
+              }
+            )
+          end
+          it { is_expected.to compile }
+          it do
+            is_expected.to contain_file(
+              '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+            ).with_content(
+              %r|/0 {\s*/type\s*"allow"\s*/suffix\s\'/suffix/path/\.\*\'\s*}|
             )
           end
         end

--- a/templates/dispatcher/dispatcher.any.erb
+++ b/templates/dispatcher/dispatcher.any.erb
@@ -33,7 +33,7 @@
 
   /renders {
   <%- @_renders.each_with_index do |renderer, idx| -%>
-    /renderer<%= idx -%> { 
+    /renderer<%= idx -%> {
       /hostname "<%= renderer['hostname'] -%>"
       /port "<%= renderer['port'] -%>"
       <%- if renderer['timeout'] -%>
@@ -57,28 +57,28 @@
     /<%= idx -%> {
       /type "<%= filter['type'] -%>"
       <%- if filter['method'] -%>
-      /method "<%= filter['method'] -%>"
+      /method <%= scope.call_function('render_farm_filter', [filter['method']]) -%>
       <%- end -%>
       <%- if filter['url'] -%>
-      /url "<%= filter['url'] -%>"
+      /url <%= scope.call_function('render_farm_filter', [filter['url']]) -%>
       <%- end -%>
       <%- if filter['query'] -%>
-      /query "<%= filter['query'] -%>"
+      /query <%= scope.call_function('render_farm_filter', [filter['query']]) -%>
       <%- end -%>
       <%- if filter['protocol'] -%>
-      /protocol "<%= filter['protocol'] -%>"
+      /protocol <%= scope.call_function('render_farm_filter', [filter['protocol']]) -%>
       <%- end -%>
       <%- if filter['path'] -%>
-      /path "<%= filter['path'] -%>"
+      /path <%= scope.call_function('render_farm_filter', [filter['path']]) -%>
       <%- end -%>
       <%- if filter['selectors'] -%>
-      /selectors '<%= filter['selectors'] -%>'
+      /selectors <%= scope.call_function('render_farm_filter', [filter['selectors']]) -%>
       <%- end -%>
       <%- if filter['extension'] -%>
-      /extension '<%= filter['extension'] -%>'
+      /extension <%= scope.call_function('render_farm_filter', [filter['extension']]) -%>
       <%- end -%>
       <%- if filter['suffix'] -%>
-      /suffix '<%= filter['suffix'] -%>'
+      /suffix <%= scope.call_function('render_farm_filter', [filter['suffix']]) -%>
       <%- end -%>
     }
     <%- end -%>


### PR DESCRIPTION
Now it is possible to define a POSIX regex in the filter config. See updated docs for more info.

Think for this PR it is best to bump the major version because the new approach is not backward compatible with existing configs (due to quotes in selector, suffix and extension now defaults to double quotes)

Resolves #100 