### PR TITLE
Add SELinux support

### DIFF
--- a/lib/puppet/provider/aem_installer/default.rb
+++ b/lib/puppet/provider/aem_installer/default.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:aem_installer).provide :default, parent: Puppet::Provider do
     @stop_file = 'stop'
     @launchpad_name = 'cq-quickstart-*-standalone*.jar'
     @repository_dir = 'repository'
-    @quickstart_fields = [:home, :version]
+    @quickstart_fields = %i[home version]
     @quickstart_regex = %r|^(\S+)/crx-quickstart/app/cq-quickstart-([0-9.]+)-standalone.*\.jar$|
     @port_regex = /^PORT=(\S+)/
     @context_root_regex = /^CONTEXT_ROOT='(\S+)'/

--- a/lib/puppet/type/aem_installer.rb
+++ b/lib/puppet/type/aem_installer.rb
@@ -66,7 +66,7 @@ This is a private type intended to start, monitor, and stop an AEM instance, ins
     autos
   end
 
-  [:user, :group].each do |type|
+  %i[user group].each do |type|
     autorequire(type) do
       if @parameters.include?(type)
         val = @parameters[type]

--- a/manifests/dispatcher.pp
+++ b/manifests/dispatcher.pp
@@ -96,6 +96,22 @@ class aem::dispatcher (
       content => template("${module_name}/dispatcher/dispatcher.farms.erb")
     }
 
+    if $facts['selinux'] {
+      File["${::aem::dispatcher::params::mod_path}/${_mod_filename}"] {
+        seltype => 'httpd_modules_t',
+      }
+
+      File["${::aem::dispatcher::params::mod_path}/mod_dispatcher.so"] {
+        seltype => 'httpd_modules_t',
+      }
+
+      selboolean { 'httpd_can_network_connect':
+        value      => 'on',
+        persistent => true,
+      }
+    }
+
+
     Anchor['aem::dispatcher::begin']
     -> File["${::aem::dispatcher::params::mod_path}/${_mod_filename}"]
     -> File["${::aem::dispatcher::params::mod_path}/mod_dispatcher.so"]

--- a/spec/classes/dispatcher_spec.rb
+++ b/spec/classes/dispatcher_spec.rb
@@ -631,4 +631,36 @@ describe 'aem::dispatcher', type: :class do
       )
     end
   end
+
+  context 'selinux' do
+    let(:facts) do
+      default_facts.merge(selinux: true)
+    end
+    let(:params) { default_params }
+
+    it { is_expected.to compile.with_all_deps }
+
+    it do
+      is_expected.to contain_file(
+        '/etc/httpd/modules/dispatcher-apache2.X-4.1.X.so'
+      ).with(
+        'seltype' => 'httpd_modules_t'
+      )
+    end
+
+    it do
+      is_expected.to contain_file(
+        '/etc/httpd/modules/mod_dispatcher.so'
+      ).with(
+        'seltype' => 'httpd_modules_t'
+      )
+    end
+
+    it do
+      is_expected.to contain_selboolean('httpd_can_network_connect').with(
+        'value'      => 'on',
+        'persistent' => true
+      )
+    end
+  end
 end


### PR DESCRIPTION
If SELinux is enabled the httpd is told to be able to network connect and the correct attributes are set for the dispatcher module

Resolves #73 