### PR TITLE
Allow use of invalidate and invalidate handler

### DIFF
--- a/manifests/dispatcher/farm.pp
+++ b/manifests/dispatcher/farm.pp
@@ -110,10 +110,6 @@ define aem::dispatcher::farm(
     }
   }
 
-  if $invalidate and $invalidate_handler {
-    fail('Both invalidate and invalidate_handler can not be set.')
-  }
-
   if $invalidate_handler {
     validate_absolute_path($invalidate_handler)
   } elsif $invalidate == undef {

--- a/spec/defines/dispatcher/farm/params_spec.rb
+++ b/spec/defines/dispatcher/farm/params_spec.rb
@@ -435,18 +435,6 @@ describe 'aem::dispatcher::farm', type: :define do
       end
     end
 
-    context 'invalidate and invalidate_handler' do
-      context 'should not allow both' do
-        let(:params) do
-          default_params.merge(
-            invalidate: { 'glob' => '*.html', 'type' => 'allow' },
-            invalidate_handler: '/path/to/handler'
-          )
-        end
-        it { expect { is_expected.to compile }.to raise_error(/Both.*can not be set./) }
-      end
-    end
-
     context 'priority' do
       context 'should accept undef' do
         let(:params) do


### PR DESCRIPTION
I did not find in the official docs why they can not be used both, checked locally and it is possible to use them simultaneously