### PR TITLE
Add check to only declare file resource if not already defined

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,10 +49,12 @@ define aem::config(
     require => File["${home}/crx-quickstart/bin/start.orig"],
   }
 
+  if !defined(File["${home}/crx-quickstart/install"]) {
   # Create the install folder in case there are any OSGi configurations; now or in the future
-  file {"${home}/crx-quickstart/install" :
-    ensure => directory,
-    mode   => '0775',
+    file {"${home}/crx-quickstart/install" :
+      ensure => directory,
+      mode   => '0775',
+    }
   }
 
   if $osgi_configs {


### PR DESCRIPTION
Update `aem::config` to not use the resource `file["${home}/crx-quickstart/install"]` if it is  already defined.

bstopp/puppet-aem#134