### PR TITLE
Extend aem_installer to rescue Errno::EAFNOSUPPORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Summary
+Minor Changes
+* Change aem_installer to rescue Address family not supported by protocol (Errno::EAFNOSUPPORT)
+
 ## 2017-01-26 - Release 3.0.0
 ### Summary
 

--- a/lib/puppet/provider/aem_installer/default.rb
+++ b/lib/puppet/provider/aem_installer/default.rb
@@ -142,7 +142,7 @@ Puppet::Type.type(:aem_installer).provide :default, parent: Puppet::Provider do
           when Net::HTTPSuccess, Net::HTTPRedirection, Net::HTTPUnauthorized
             return if desired_state == :on
           end
-        rescue SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTDOWN, Errno::EHOSTUNREACH, Errno::ETIMEDOUT
+        rescue SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTDOWN, Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::EAFNOSUPPORT
           return if desired_state == :off
         end
         sleep @property_hash[:snooze]


### PR DESCRIPTION
Extend aem_installer to rescue `Address family not supported by 
protocol` (Errno::EAFNOSUPPORT) #139 