### PR TITLE
Fix remote debug port for java 11

### DIFF
--- a/templates/start.erb
+++ b/templates/start.erb
@@ -53,7 +53,7 @@ if [ -n "${SAMPLE_CONTENT}" ]; then
 fi
 
 if [ -n "${DEBUG_PORT}" ]; then
-    DEBUG_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${DEBUG_PORT}"
+    DEBUG_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:${DEBUG_PORT}"
 fi
 
 JVM_OPTS="${JVM_MEM_OPTS} ${DEFAULT_JVM_OPTS} ${JVM_OPTS} ${DEBUG_OPTS} -Dsling.run.modes=${RUN_MODES}"


### PR DESCRIPTION
Add '*:' to make sure the debug port is open for remote debugging in java 11 (default only localhost since java 9)